### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/ccontray/86767851-d4de-4c05-afa5-9a9be4472560/2732fe84-6408-4ed9-98fa-bf86d30b3ff5/_apis/work/boardbadge/f4730e0e-25a3-4a1f-995f-de9431240585)](https://dev.azure.com/ccontray/86767851-d4de-4c05-afa5-9a9be4472560/_boards/board/t/2732fe84-6408-4ed9-98fa-bf86d30b3ff5/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/ccontray/86767851-d4de-4c05-afa5-9a9be4472560/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.